### PR TITLE
Update 2_BashScripting.md

### DIFF
--- a/Practicals/Bash_Practicals/2_BashScripting.md
+++ b/Practicals/Bash_Practicals/2_BashScripting.md
@@ -59,7 +59,7 @@ echo ~
 The next part of the practical will make use of a file that you will need to download. First, make sure you are in your `Project_0` sub-directory.
 
 ```
-cd ./Project_0
+cd ~/Project_0/
 ```
 
 Get the file by running the following command.
@@ -116,7 +116,7 @@ less SeqIDs.txt
 Now we can add the sequence identifiers, but first you need to `gunzip` the compressed file.
 
 ```
-gunzip drosophila_melanogaster/ncrna/Drosophila_melanogaster.BDGP6.ncrna.fa.gz
+gunzip Drosophila_melanogaster.BDGP6.ncrna.fa.gz
 ```
 
 ```
@@ -460,8 +460,7 @@ Now open this using the using the text editor *nano*:
 nano wellDone.sh
 ```
 
-Enter the above code into this file **setting your actual name as the ME variable**,  and save it by using `Ctrl+o` (indicated as `^O`) in the nano screen.
-Once you're finished, you can exit the `nano` editor by hitting `Ctrl+x` (written as `^X`).
+Once you're finished, you can exit the `nano` editor by hitting `Ctrl+x` (written as `^X`), then confirm saving changes with `y`, and finally press `Enter` to return to the terminal.
 Assuming that you've entered everything correctly, we can now execute this script by simply entering
 
 ```


### PR DESCRIPTION
1. line 62: change from `cd ./Project_0` to `cd ~/Project_0/`. 
Reason: Part 1 is already in Project_0. Using Project_0 might be confusing, so switching to an absolute path for clarity

2. line119: Change from `gunzip drosophila_melanogaster/ncrna/Drosophila_melanogaster.BDGP6.ncrna.fa.gz` to `gunzip Drosophila_melanogaster.BDGP6.ncrna.fa.gz`
Reason: Incorrect file name prevents gunzip from working

3. line463: Change from

```
Once you’re finished, you can exit the nano editor by hitting Ctrl+x (written as ^X). Assuming that you’ve entered everything correctly, we can now execute this script by simply entering
```

to

```
Once you're finished, you can exit the `nano` editor by hitting `Ctrl+x` (written as `^X`), then confirm saving changes with `y`, and finally press `Enter` to return to the terminal.
```

Reason: In RStudio Terminal with nano, Ctrl+O conflicts with the open file shortcut. Using Ctrl+X may be clearer.