### PR TITLE
Suggested edits for Clinical Genomics Practical: Part 1 Variant Annotation

### DIFF
--- a/Practicals/variants_clinical/variant_annotation.md
+++ b/Practicals/variants_clinical/variant_annotation.md
@@ -5,7 +5,7 @@
 * TOC
 {:toc}
 
-## Some backgound on Clinical Genomics
+## Some background on Clinical Genomics
 
 Clinical genomics and mendelian genetics can be separated into two groups based on their stated analysis goals; Diagnostics and Research.
 Many labs in major hospitals, independent research institutes and universities do a mixture of both work.
@@ -148,7 +148,7 @@ It is also helpful in finding potential loss-of-function (pLoF) variants.
   - Search gnomAD for the gene SATB1
   - Count the number of missense variants and list the pLoF variants in SATB1
 - Look up the variant `14-82565377-G-C` (rs75115269) and identify its allele frequency in Ashkenazi Jews
-- Can you find its equivalent genomics coordinates and allele frequency for the newer hg38 reference genome?
+- Can you find its equivalent genomics coordinates and allele frequency for the older hg19 reference genome?
 
 ---
 


### PR DESCRIPTION
Clinical Genomics Practical: Part 1 Variant Annotation

1. Line 151: - Can you find its equivalent genomics coordinates and allele frequency for the older hg19 reference genome?

I believe gnomAD uses hg38 by default, so the question is unclear;  perhaps it should ask about frequencies based on the older hg19 reference.

2. Line 187: VEP Variant Types image is missing